### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "grunt-contrib-clean":  "~1.0.0"
     },
     "peerDependencies": {
-        "grunt":                "~1.0.1"
+        "grunt":                ">=0.4.0"
     },
     "engines": {
         "node":                 ">=0.10.0"


### PR DESCRIPTION
Grunt update causes

```
npm WARN peerDependencies The peer dependency grunt@~1.0.1 included from grunt-extend-config will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
```

See issue: http://gruntjs.com/blog/2016-04-04-grunt-1.0.0-released#peer-dependencies
